### PR TITLE
Fix PVC problem of Clickhouse

### DIFF
--- a/clickhouse/helm/clickhouse/templates/clickhouse-installation.yaml
+++ b/clickhouse/helm/clickhouse/templates/clickhouse-installation.yaml
@@ -10,6 +10,7 @@ spec:
       provisioner: Operator
     templates: 
       serviceTemplate: default
+      volumeClaimTemplate: default
   
   configuration:
     {{- if .Values.clickhouse.configuration.settings }}


### PR DESCRIPTION
PersistentVolumeClaim is not created even if `volumeClaimTemplates` section is appended.
Add default templates spec to apply `volumeClaimTemplates` section correctly.